### PR TITLE
Add test for using StrEnumWithDoc with unique decorator

### DIFF
--- a/tests/test_str_enum_with_doc.py
+++ b/tests/test_str_enum_with_doc.py
@@ -1,3 +1,5 @@
+from enum import unique
+
 import pytest
 
 from veriq import StrEnumWithDoc
@@ -68,3 +70,13 @@ def test_enum_members_parametrized(
 ) -> None:
     assert member.value == expected_value
     assert member.__doc__ == expected_doc
+
+
+def test_unique_decorator_rejects_duplicate_values_with_different_docs() -> None:
+    """Ensure @unique considers only values, not docstrings."""
+    with pytest.raises(ValueError, match="duplicate values"):
+
+        @unique
+        class DuplicateMode(StrEnumWithDoc):
+            NORMAL = "same_value", "First docstring"
+            DUPLICATE = "same_value", "Different docstring"


### PR DESCRIPTION
## Summary

Add a test case to verify that `StrEnumWithDoc` works correctly with the standard library's `@unique` decorator.

## Changes

- Import `unique` from `enum` module in test file
- Add `test_unique_decorator_rejects_duplicate_values_with_different_docs()` test

## What this test verifies

The test ensures that when `@unique` is applied to a `StrEnumWithDoc` subclass, it correctly rejects duplicate values even when docstrings differ. This confirms that `@unique` considers only the enum values (not the docstrings) when checking for duplicates.

## Example

```python
@unique
class DuplicateMode(StrEnumWithDoc):
    NORMAL = "same_value", "First docstring"
    DUPLICATE = "same_value", "Different docstring"  # Raises ValueError
```
