### PR TITLE
Fix false positive type mismatch for StrEnum fields in veriq update

### DIFF
--- a/src/veriq/_update.py
+++ b/src/veriq/_update.py
@@ -84,6 +84,12 @@ def deep_merge(
 
         return result, warnings
 
+    # Handle StrEnum case: StrEnum values are stored as plain strings in TOML files,
+    # so when comparing a StrEnum default with a string from TOML, they should be
+    # treated as compatible types (StrEnum inherits from str).
+    if isinstance(new_default, str) and isinstance(existing, str):
+        return existing, warnings
+
     # If both are the same type (and not dict), prefer existing
     if type(new_default) is type(existing):
         return existing, warnings


### PR DESCRIPTION
StrEnum values are stored as plain strings in TOML files. When running
`veriq update`, comparing a StrEnum default with a string from TOML was
triggering a false positive type mismatch warning because `type(StrEnum)`
is not identical to `type(str)`.

Fixed by checking if both values are string instances (which includes
StrEnum since it inherits from str) before the strict type identity check.

https://claude.ai/code/session_01Y3NN6ymifJyFhjwzJxyqzH