### PR TITLE
Fix type mismatch false positive when the existing value is an integer and the schema is float

### DIFF
--- a/src/veriq/_update.py
+++ b/src/veriq/_update.py
@@ -90,6 +90,12 @@ def deep_merge(
     if isinstance(new_default, str) and isinstance(existing, str):
         return existing, warnings
 
+    # Handle numeric types: int is compatible with float
+    # (TOML may store 100 as int, but schema expects float)
+    # Keep as int to preserve original TOML formatting; Pydantic will coerce at validation time
+    if isinstance(new_default, float) and isinstance(existing, int):
+        return existing, warnings
+
     # If both are the same type (and not dict), prefer existing
     if type(new_default) is type(existing):
         return existing, warnings

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -284,3 +284,30 @@ def test_deep_merge_strenum_nested():
 
     assert result == {"config": {"mode": "safe", "value": 20}}
     assert len(warnings) == 0
+
+
+def test_deep_merge_int_compatible_with_float():
+    """Test that int values are compatible with float schema fields.
+
+    TOML files may store integer values (e.g., 100) for fields that the schema
+    defines as float. These should be treated as compatible without warnings,
+    and the int value should be preserved to maintain TOML formatting.
+    """
+    new_default = {"temperature": 0.0}
+    existing = {"temperature": 100}  # int from TOML
+
+    result, warnings = deep_merge(new_default, existing)
+
+    assert result == {"temperature": 100}  # Preserved as int
+    assert len(warnings) == 0
+
+
+def test_deep_merge_int_compatible_with_float_nested():
+    """Test int/float compatibility in nested structures."""
+    new_default = {"sensor": {"temperature": 0.0, "pressure": 0.0}}
+    existing = {"sensor": {"temperature": 25, "pressure": 101}}
+
+    result, warnings = deep_merge(new_default, existing)
+
+    assert result == {"sensor": {"temperature": 25, "pressure": 101}}
+    assert len(warnings) == 0


### PR DESCRIPTION
## Summary

Fix false positive type mismatch warnings when TOML files contain integer values for fields that the schema defines as float.

## Problem

When a TOML file contains an integer value (e.g., `temperature = 100`) for a field that the Pydantic schema defines as `float`, the `deep_merge` function incorrectly reports a type mismatch warning. This is a false positive because:

1. TOML parsers naturally store `100` as an integer
2. Pydantic will correctly coerce `int` to `float` during validation
3. Users should not be warned about valid, compatible data

## Solution

Add an early return in `deep_merge` that treats `int` values as compatible with `float` schema fields. The original `int` value is preserved to maintain TOML formatting consistency.

## Changes

- `src/veriq/_update.py`: Add int/float compatibility check before the general type mismatch logic
- `tests/test_update.py`: Add two test cases covering flat and nested structures