### PR TITLE
Add `with_range` decorator for creating range-based `IntEnum`

### DIFF
--- a/src/veriq/__init__.py
+++ b/src/veriq/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "is_valid_verification_return_type",
     "load_model_data_from_toml",
     "validate_external_data",
+    "with_range",
 ]
 
 # bounded-models integration
@@ -50,6 +51,7 @@ from ._graph import DependencyGraph
 from ._io import export_to_toml, input_base_dir, load_model_data_from_toml
 from ._ir import GraphSpec, NodeKind, NodeSpec, build_graph_spec
 from ._models import Project, Ref, Requirement, Scope, is_valid_verification_return_type
+from ._range_enum import with_range
 from ._relations import depends
 from ._str_enum_with_doc import StrEnumWithDoc
 from ._table import Table

--- a/src/veriq/_range_enum.py
+++ b/src/veriq/_range_enum.py
@@ -1,0 +1,73 @@
+"""Module providing a decorator to create IntEnum with range-based members."""
+
+from enum import IntEnum
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_IntEnumT = TypeVar("_IntEnumT", bound=IntEnum)
+
+
+def with_range(
+    stop: int,
+    /,
+    start: int = 0,
+    step: int = 1,
+    prefix: str = "_",
+) -> Callable[[type[_IntEnumT]], type[_IntEnumT]]:
+    """Decorator to generate range-based IntEnum members.
+
+    Creates enum members with names "{prefix}{i}" for each i in range(start, stop, step).
+
+    Args:
+        stop: The end value (exclusive), like range().
+        start: The start value (default 0).
+        step: The step between values (default 1).
+        prefix: Prefix for member names (default "_").
+
+    Returns:
+        A decorator that transforms an IntEnum class.
+
+    Examples:
+        >>> @with_range(3)
+        ... class Status(IntEnum):
+        ...     pass
+        >>> list(Status)
+        [<Status._0: 0>, <Status._1: 1>, <Status._2: 2>]
+
+        >>> @with_range(10, start=5)
+        ... class Levels(IntEnum):
+        ...     pass
+        >>> list(Levels)
+        [<Levels._5: 5>, <Levels._6: 6>, ...]
+
+        >>> @with_range(10, step=2, prefix="N_")
+        ... class EvenNumbers(IntEnum):
+        ...     pass
+        >>> EvenNumbers.N_0
+        <EvenNumbers.N_0: 0>
+
+        >>> @with_range(3)
+        ... class Mixed(IntEnum):
+        ...     SPECIAL = 100
+        >>> list(Mixed)
+        [<Mixed._0: 0>, <Mixed._1: 1>, <Mixed._2: 2>, <Mixed.SPECIAL: 100>]
+
+    """
+
+    def decorator(cls: type[_IntEnumT]) -> type[_IntEnumT]:
+        # Generate range-based members
+        members = {f"{prefix}{i}": i for i in range(start, stop, step)}
+
+        # Collect existing members defined in the class
+        existing_members = {
+            name: value
+            for name, value in vars(cls).items()
+            if not name.startswith("_") and isinstance(value, int)
+        }
+        members.update(existing_members)
+
+        return IntEnum(cls.__name__, members)  # type: ignore[return-value]
+
+    return decorator

--- a/tests/test_range_enum.py
+++ b/tests/test_range_enum.py
@@ -1,0 +1,177 @@
+from enum import IntEnum
+
+import pytest
+
+from veriq import with_range
+
+
+@with_range(3)
+class SimpleEnum(IntEnum):
+    pass
+
+
+@with_range(10, start=5)
+class StartEnum(IntEnum):
+    pass
+
+
+@with_range(10, step=2)
+class StepEnum(IntEnum):
+    pass
+
+
+@with_range(10, start=2, step=3)
+class StartStepEnum(IntEnum):
+    pass
+
+
+@with_range(3, prefix="IDX_")
+class PrefixEnum(IntEnum):
+    pass
+
+
+@with_range(3)
+class MixedEnum(IntEnum):
+    SPECIAL = 100
+    ERROR = -1
+
+
+def test_simple_range() -> None:
+    members = list(SimpleEnum)
+    assert len(members) == 3
+    assert SimpleEnum._0 == 0  # ty: ignore[unresolved-attribute]
+    assert SimpleEnum._1 == 1  # ty: ignore[unresolved-attribute]
+    assert SimpleEnum._2 == 2  # ty: ignore[unresolved-attribute]
+
+
+def test_range_with_start() -> None:
+    members = list(StartEnum)
+    assert len(members) == 5
+    assert StartEnum._5 == 5  # ty: ignore[unresolved-attribute]
+    assert StartEnum._9 == 9  # ty: ignore[unresolved-attribute]
+    assert not hasattr(StartEnum, "_0")
+    assert not hasattr(StartEnum, "_10")
+
+
+def test_range_with_step() -> None:
+    members = list(StepEnum)
+    assert len(members) == 5
+    assert StepEnum._0 == 0  # ty: ignore[unresolved-attribute]
+    assert StepEnum._2 == 2  # ty: ignore[unresolved-attribute]
+    assert StepEnum._4 == 4  # ty: ignore[unresolved-attribute]
+    assert StepEnum._6 == 6  # ty: ignore[unresolved-attribute]
+    assert StepEnum._8 == 8  # ty: ignore[unresolved-attribute]
+    assert not hasattr(StepEnum, "_1")
+    assert not hasattr(StepEnum, "_10")
+
+
+def test_range_with_start_and_step() -> None:
+    members = list(StartStepEnum)
+    assert len(members) == 3
+    assert StartStepEnum._2 == 2  # ty: ignore[unresolved-attribute]
+    assert StartStepEnum._5 == 5  # ty: ignore[unresolved-attribute]
+    assert StartStepEnum._8 == 8  # ty: ignore[unresolved-attribute]
+
+
+def test_custom_prefix() -> None:
+    members = list(PrefixEnum)
+    assert len(members) == 3
+    assert PrefixEnum.IDX_0 == 0  # ty: ignore[unresolved-attribute]
+    assert PrefixEnum.IDX_1 == 1  # ty: ignore[unresolved-attribute]
+    assert PrefixEnum.IDX_2 == 2  # ty: ignore[unresolved-attribute]
+    assert not hasattr(PrefixEnum, "_0")
+
+
+def test_mixed_with_explicit_members() -> None:
+    members = list(MixedEnum)
+    assert len(members) == 5
+    # Range members
+    assert MixedEnum._0 == 0  # ty: ignore[unresolved-attribute]
+    assert MixedEnum._1 == 1  # ty: ignore[unresolved-attribute]
+    assert MixedEnum._2 == 2  # ty: ignore[unresolved-attribute]
+    # Explicit members
+    assert MixedEnum.SPECIAL == 100
+    assert MixedEnum.ERROR == -1
+
+
+def test_enum_is_int() -> None:
+    assert isinstance(SimpleEnum._0, int)  # ty: ignore[unresolved-attribute]
+    assert SimpleEnum._0 + 1 == 1  # ty: ignore[unresolved-attribute]
+    assert SimpleEnum._2 * 2 == 4  # ty: ignore[unresolved-attribute]
+
+
+def test_enum_by_value() -> None:
+    assert SimpleEnum(0) is SimpleEnum._0  # ty: ignore[unresolved-attribute]
+    assert SimpleEnum(2) is SimpleEnum._2  # ty: ignore[unresolved-attribute]
+
+
+def test_enum_by_name() -> None:
+    assert SimpleEnum["_0"] is SimpleEnum._0  # ty: ignore[unresolved-attribute]
+    assert SimpleEnum["_2"] is SimpleEnum._2  # ty: ignore[unresolved-attribute]
+
+
+def test_enum_iteration_order() -> None:
+    # IntEnum iterates in definition order, which should be value order for range
+    values = [m.value for m in SimpleEnum]
+    assert values == [0, 1, 2]
+
+
+def test_enum_membership() -> None:
+    assert SimpleEnum._0 in SimpleEnum  # ty: ignore[unresolved-attribute]
+    assert 0 in [m.value for m in SimpleEnum]
+
+
+@pytest.mark.parametrize(
+    ("member", "expected_value"),
+    [
+        (SimpleEnum._0, 0),  # ty: ignore[unresolved-attribute]
+        (SimpleEnum._1, 1),  # ty: ignore[unresolved-attribute]
+        (SimpleEnum._2, 2),  # ty: ignore[unresolved-attribute]
+    ],
+)
+def test_simple_enum_parametrized(member: SimpleEnum, expected_value: int) -> None:
+    assert member.value == expected_value
+
+
+@pytest.mark.parametrize(
+    ("stop", "start", "step", "expected_count"),
+    [
+        (5, 0, 1, 5),
+        (10, 5, 1, 5),
+        (10, 0, 2, 5),
+        (10, 1, 3, 3),
+        (0, 0, 1, 0),
+        (1, 0, 1, 1),
+    ],
+)
+def test_range_parameters(stop: int, start: int, step: int, expected_count: int) -> None:
+    @with_range(stop, start=start, step=step)
+    class DynamicEnum(IntEnum):
+        pass
+
+    assert len(list(DynamicEnum)) == expected_count
+
+
+def test_empty_range() -> None:
+    @with_range(0)
+    class EmptyEnum(IntEnum):
+        pass
+
+    assert len(list(EmptyEnum)) == 0
+
+
+def test_single_member() -> None:
+    @with_range(1)
+    class SingleEnum(IntEnum):
+        pass
+
+    assert len(list(SingleEnum)) == 1
+    assert SingleEnum._0 == 0  # ty: ignore[unresolved-attribute]
+
+
+def test_class_name_preserved() -> None:
+    @with_range(3)
+    class MyCustomName(IntEnum):
+        pass
+
+    assert MyCustomName.__name__ == "MyCustomName"


### PR DESCRIPTION
## Summary

Adds a new `with_range` decorator that simplifies creating `IntEnum` classes with sequential integer members based on Python's `range()` signature.

## Changes

- **New file:** `src/veriq/_range_enum.py` - Implementation of the `with_range` decorator
- **New file:** `tests/test_range_enum.py` - 23 tests covering all functionality
- **Updated:** `src/veriq/__init__.py` - Export `with_range` in public API

## Usage

```python
from enum import IntEnum
from veriq import with_range

# Basic: creates _0, _1, _2
@with_range(3)
class TimeIndex(IntEnum):
    ...

# With start and step
@with_range(10, start=5, step=2)
class Levels(IntEnum):
    ...

# Custom prefix
@with_range(5, prefix="IDX_")
class Indices(IntEnum):
    ...

# Mix with explicit members
@with_range(3)
class Status(IntEnum):
    SPECIAL = 100
```

## API

```python
def with_range(
    stop: int,
    /,
    start: int = 0,
    step: int = 1,
    prefix: str = "_",
) -> Callable[[type[IntEnum]], type[IntEnum]]:
```

Parameters mirror Python's `range()` function, with an additional `prefix` parameter for member names.
