### PR TITLE
feat: add CI-friendly `--check` mode to `veriq schema`

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -140,6 +140,19 @@ veriq schema PROJECT_PATH -o OUTPUT [OPTIONS]
 | `--output PATH` | `-o` | Path to output JSON schema file (required) |
 | `--project NAME` | | Name of the project variable |
 | `--indent N` | | JSON indentation spaces (default: 2) |
+| `--check` | | Check that the schema file is up to date without writing (CI gate) |
+
+**Check mode:**
+
+With `--check`, nothing is written. The command compares the file at
+`--output` against the freshly generated schema and reports any differences.
+The comparison is semantic (parsed JSON), so indentation or key order does
+not matter.
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Schema file is up to date |
+| `1` | Schema file is missing, not valid JSON, or out of date |
 
 **Examples:**
 
@@ -149,6 +162,16 @@ veriq schema my_project.py -o schema.json
 
 # With custom indentation
 veriq schema my_project.py -o schema.json --indent 4
+
+# CI gate: fail if the committed schema was not regenerated after model changes
+veriq schema my_project.py -o schema.json --check
+```
+
+**CI example (GitHub Actions):**
+
+```yaml
+- name: Check committed schema is in sync with the models
+  run: uv run veriq schema my_project.py -o schema.json --check
 ```
 
 The generated schema can be used for:

--- a/src/veriq/_cli/main.py
+++ b/src/veriq/_cli/main.py
@@ -5,7 +5,7 @@ import json
 import logging
 import tomllib
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Any, NoReturn
 
 if TYPE_CHECKING:
     from veriq._models import Project
@@ -398,6 +398,93 @@ def check(
     err_console.print()
 
 
+def _load_committed_schema(output: Path) -> dict[str, Any]:
+    """Load the committed schema file for checking, exiting with a clear message on failure."""
+    if not output.exists():
+        err_console.print(f"[red]✗ Schema file not found: {output}[/red]")
+        err_console.print("[yellow]i Run 'veriq schema' without --check to generate it[/yellow]")
+        raise typer.Exit(code=1)
+
+    try:
+        committed_schema = json.loads(output.read_text())
+    except OSError as e:
+        err_console.print(f"[red]✗ Cannot read schema file: {escape(str(e))}[/red]")
+        raise typer.Exit(code=1) from e
+    except json.JSONDecodeError as e:
+        err_console.print(f"[red]✗ Schema file is not valid JSON: {escape(str(e))}[/red]")
+        err_console.print("[yellow]i Run 'veriq schema' without --check to regenerate it[/yellow]")
+        raise typer.Exit(code=1) from e
+
+    if not isinstance(committed_schema, dict):
+        err_console.print(f"[red]✗ Schema file is not a JSON object (got {type(committed_schema).__name__})[/red]")
+        err_console.print("[yellow]i Run 'veriq schema' without --check to regenerate it[/yellow]")
+        raise typer.Exit(code=1)
+
+    return committed_schema
+
+
+def _run_schema_check(generated_schema: dict[str, Any], output: Path) -> NoReturn:
+    """Compare the generated schema against the committed file and exit.
+
+    The comparison is semantic (parsed JSON), so cosmetic differences such as
+    indentation or key order do not fail the check.
+
+    Exit codes:
+    - 0: schema file is up to date
+    - 1: schema file is missing, not valid JSON, or out of date
+    """
+    err_console.print(f"[cyan]Checking committed schema:[/cyan] {output}")
+
+    committed_schema = _load_committed_schema(output)
+
+    # Strict semantic comparison: serialized form preserves int/float/bool
+    # distinctions that plain dict equality would miss (100 == 100.0)
+    if json.dumps(committed_schema, sort_keys=True) == json.dumps(generated_schema, sort_keys=True):
+        err_console.print()
+        err_console.print("[green]✓ Schema file is up to date[/green]")
+        err_console.print()
+        raise typer.Exit(code=0)
+
+    entries = diff_dicts(committed_schema, generated_schema)
+    if not entries:
+        # Values compared equal (e.g. 100 vs 100.0) but their JSON types differ
+        err_console.print()
+        err_console.print("[red]✗ Schema file is out of date (numeric/boolean type difference)[/red]")
+        err_console.print("[yellow]i Run 'veriq schema' without --check to regenerate it[/yellow]")
+        err_console.print()
+        raise typer.Exit(code=1)
+
+    err_console.print()
+    err_console.print(f"[red]✗ Schema file is out of date ({len(entries)} difference(s)):[/red]")
+
+    # Fold long content instead of truncating: the report must stay complete for CI logs
+    diff_table = Table(show_header=True, header_style="bold")
+    diff_table.add_column("Path", overflow="fold")
+    diff_table.add_column("Status")
+    diff_table.add_column("Committed", overflow="fold")
+    diff_table.add_column("Generated", overflow="fold")
+
+    for entry in entries:
+        entry_path = escape(format_toml_path(entry.path))
+        if entry.kind is DiffKind.REMOVED:
+            diff_table.add_row(entry_path, "[red]obsolete[/red]", escape(repr(entry.left)), "—")
+        elif entry.kind is DiffKind.ADDED:
+            diff_table.add_row(entry_path, "[green]missing[/green]", "—", escape(repr(entry.right)))
+        else:
+            diff_table.add_row(
+                entry_path,
+                "[yellow]changed[/yellow]",
+                escape(repr(entry.left)),
+                escape(repr(entry.right)),
+            )
+
+    err_console.print(diff_table)
+    err_console.print()
+    err_console.print("[yellow]i Run 'veriq schema' without --check to regenerate it[/yellow]")
+    err_console.print()
+    raise typer.Exit(code=1)
+
+
 @app.command()
 def schema(
     path: Annotated[
@@ -417,8 +504,17 @@ def schema(
         int,
         typer.Option("--indent", help="JSON indentation spaces"),
     ] = 2,
+    check: Annotated[
+        bool,
+        typer.Option("--check", help="Check that the schema file is up to date without writing (CI gate)"),
+    ] = False,
 ) -> None:
-    """Generate JSON schema for the project input model."""
+    """Generate JSON schema for the project input model.
+
+    With --check, nothing is written: the command compares the file at
+    --output against the freshly generated schema and exits 0 when it is
+    up to date, or 1 when it is missing, not valid JSON, or out of date.
+    """
     err_console.print()
 
     # Load config
@@ -442,6 +538,10 @@ def schema(
     err_console.print("[cyan]Generating input model JSON schema...[/cyan]")
     input_model = project.input_model()
     json_schema = input_model.model_json_schema()
+
+    if check:
+        # Compare against the committed file and exit; writes nothing
+        _run_schema_check(json_schema, output)
 
     # Write to file
     err_console.print(f"[cyan]Writing schema to:[/cyan] {output}")

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -1,0 +1,153 @@
+"""Tests for the `veriq schema --check` CLI mode (CI gate for schema-artifact drift)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+EXIT_OK = 0
+EXIT_STALE = 1
+
+PROJECT_CODE = """
+from pydantic import BaseModel
+
+import veriq as vq
+
+
+class Design(BaseModel):
+    voltage: float
+    capacity: float = 100.0
+
+
+project = vq.Project(name="TestProject")
+scope = vq.Scope(name="Power")
+project.add_scope(scope)
+scope.root_model()(Design)
+"""
+
+
+@pytest.fixture
+def project_file(tmp_path: Path) -> Path:
+    """Write a minimal project script for CLI invocation."""
+    path = tmp_path / "test_project.py"
+    path.write_text(PROJECT_CODE)
+    return path
+
+
+def run_schema(project_file: Path, schema_file: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    """Run `veriq schema` as a subprocess and return the completed process."""
+    return subprocess.run(  # noqa: S603
+        ["uv", "run", "veriq", "schema", str(project_file), "-o", str(schema_file), *extra_args],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def generated_schema_file(project_file: Path, tmp_path: Path) -> Path:
+    """Generate a schema file that is in sync with the project."""
+    schema_file = tmp_path / "schema.json"
+    result = run_schema(project_file, schema_file)
+    assert result.returncode == EXIT_OK, f"schema generation failed: {result.stderr}"
+    return schema_file
+
+
+def test_check_in_sync_schema_exits_zero(project_file: Path, generated_schema_file: Path) -> None:
+    """A freshly generated schema file passes the check."""
+    result = run_schema(project_file, generated_schema_file, "--check")
+
+    assert result.returncode == EXIT_OK, f"stderr: {result.stderr}"
+
+
+def test_check_is_semantic_not_textual(project_file: Path, generated_schema_file: Path) -> None:
+    """Cosmetic differences (indentation, key order) do not fail the check."""
+    schema = json.loads(generated_schema_file.read_text())
+    # Re-dump with different indentation, sorted keys, and no trailing newline
+    generated_schema_file.write_text(json.dumps(schema, indent=4, sort_keys=True))
+
+    result = run_schema(project_file, generated_schema_file, "--check")
+
+    assert result.returncode == EXIT_OK, f"stderr: {result.stderr}"
+
+
+def test_check_stale_schema_exits_nonzero(project_file: Path, generated_schema_file: Path) -> None:
+    """A schema file that no longer matches the models fails the check."""
+    schema = json.loads(generated_schema_file.read_text())
+    # Simulate an outdated artifact: drop a property the current model has
+    del schema["$defs"]["Design"]["properties"]["capacity"]
+    generated_schema_file.write_text(json.dumps(schema))
+
+    result = run_schema(project_file, generated_schema_file, "--check")
+
+    assert result.returncode == EXIT_STALE, f"stderr: {result.stderr}"
+    assert "capacity" in result.stderr
+
+
+def test_check_missing_schema_file_exits_nonzero(project_file: Path, tmp_path: Path) -> None:
+    """A missing schema file fails the check."""
+    missing_file = tmp_path / "missing.json"
+
+    result = run_schema(project_file, missing_file, "--check")
+
+    assert result.returncode == EXIT_STALE, f"stderr: {result.stderr}"
+    assert not missing_file.exists()
+
+
+def test_check_malformed_schema_file_exits_nonzero(project_file: Path, tmp_path: Path) -> None:
+    """A schema file that is not valid JSON fails the check."""
+    schema_file = tmp_path / "schema.json"
+    schema_file.write_text("{ not json")
+
+    result = run_schema(project_file, schema_file, "--check")
+
+    assert result.returncode == EXIT_STALE, f"stderr: {result.stderr}"
+
+
+def test_check_non_object_json_exits_nonzero_without_traceback(project_file: Path, tmp_path: Path) -> None:
+    """A schema file containing valid JSON that is not an object fails cleanly."""
+    schema_file = tmp_path / "schema.json"
+    schema_file.write_text("[1, 2, 3]")
+
+    result = run_schema(project_file, schema_file, "--check")
+
+    assert result.returncode == EXIT_STALE, f"stderr: {result.stderr}"
+    assert "Traceback" not in result.stderr
+
+
+def test_check_output_is_directory_exits_nonzero_without_traceback(project_file: Path, tmp_path: Path) -> None:
+    """Pointing --output at a directory fails cleanly instead of crashing."""
+    schema_dir = tmp_path / "schema.json"
+    schema_dir.mkdir()
+
+    result = run_schema(project_file, schema_dir, "--check")
+
+    assert result.returncode == EXIT_STALE, f"stderr: {result.stderr}"
+    assert "Traceback" not in result.stderr
+
+
+def test_check_detects_numeric_type_drift(project_file: Path, generated_schema_file: Path) -> None:
+    """An int-for-float value (100 vs 100.0) is drift, not equality."""
+    content = generated_schema_file.read_text()
+    assert "100.0" in content, "expected the capacity default in the generated schema"
+    generated_schema_file.write_text(content.replace("100.0", "100"))
+
+    result = run_schema(project_file, generated_schema_file, "--check")
+
+    assert result.returncode == EXIT_STALE, f"stderr: {result.stderr}"
+
+
+def test_check_never_writes(project_file: Path, generated_schema_file: Path) -> None:
+    """--check must not modify the schema file even when it is stale."""
+    stale_content = json.dumps({"outdated": True})
+    generated_schema_file.write_text(stale_content)
+
+    run_schema(project_file, generated_schema_file, "--check")
+
+    assert generated_schema_file.read_text() == stale_content


### PR DESCRIPTION
## Summary

Implements **Part A of #261**: a CI-friendly check mode for schema-artifact drift. Independent of Part B (#267) — different command, no shared new code.

- **`veriq schema -o schema.json --check`** regenerates the input-model JSON schema in memory, compares it against the committed file, and **writes nothing**.
- Exit codes:
  | Code | Meaning |
  |------|---------|
  | `0` | Schema file is up to date |
  | `1` | Schema file is missing, unreadable, not a JSON object, or out of date |
- The comparison is **semantic** (parsed JSON, serialized with `sort_keys` for the equality test), so indentation, key order, and trailing whitespace don't matter — while int/float/bool type differences (`100` vs `100.0`) are still detected as drift.
- On drift, an **untruncated** diff table (Committed vs Generated, columns fold instead of ellipsizing in narrow terminals) reusing `diff_dicts` from `_diff.py`.
- Robust failure modes verified by tests: missing file, malformed JSON, valid-but-non-object JSON (e.g. an array), and `-o` pointing at a directory all fail cleanly with a message — no tracebacks.

This is the standard "generated artifact must be regenerated" CI pattern (cf. `prettier --check`), enabling gates for the committed `examples/*.in.schema.json` files.

## Test plan

- [x] New `tests/test_schema_check.py` (9 CLI-level tests): in-sync → 0; reformatted (indent/key order) → 0; stale → 1 (drift path named); numeric type drift (`100.0` → `100`) → 1; missing file → 1 (and not created); malformed JSON → 1; non-object JSON → 1 without traceback; `-o` is a directory → 1 without traceback; `--check` never writes
- [x] Full suite: 654 passed
- [x] `just ruff` / `just tc` pass
- [x] Reviewed by code-reviewer agent; all HIGH/MEDIUM findings (non-object JSON crash, directory `-o` traceback, int/float tolerance) fixed with regression tests
- [x] Docs updated (`docs/cli-reference.md`) incl. exit-code table and GitHub Actions example

With #267, this completes both parts of #261.